### PR TITLE
Dependency fix

### DIFF
--- a/etc/module.xml
+++ b/etc/module.xml
@@ -3,6 +3,10 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="../../../../../lib/internal/Magento/Framework/Module/etc/module.xsd">
 
-    <module name="Ess_M2ePro" setup_version="1.1.0"></module>
+    <module name="Ess_M2ePro" setup_version="1.1.0">
+        <sequence>
+            <module name="Magento_Config"/>
+        </sequence>        
+    </module>
 
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="../../../../../lib/internal/Magento/Framework/Module/etc/module.xsd">
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
 
     <module name="Ess_M2ePro" setup_version="1.1.0">
         <sequence>


### PR DESCRIPTION
Fixed so this module is installed when magento config module is created (and the tables have been created)

Our build tool fails because this module lacks the proper dependencies. core_config_data table hasn't been created when it tries to access it.
