### PR TITLE
added Magento_Paypal dependency

### DIFF
--- a/etc/module.xml
+++ b/etc/module.xml
@@ -12,6 +12,7 @@
             <module name="Magento_Customer" />
             <module name="Magento_Eav" />
             <module name="Magento_Payment" />
+            <module name="Magento_Paypal" />
             <module name="Magento_Quote" />
             <module name="Magento_RequireJs" />
             <module name="Magento_Sales" />


### PR DESCRIPTION
You use `\Magento\Paypal` here:

https://github.com/m2epro/magento2-extension/blob/b4feff6c07eec6f1e7898bcc6cefcb52e20e6fa4/Block/Adminhtml/Ebay/Template/Payment/Edit/Form/Data.php#L21

Hence, you should define a dependency on the Paypal module. If possible, it would of course be better to avoid the dependency altogether.