### PR TITLE
Check for installation

### DIFF
--- a/Plugin/AbstractPlugin.php
+++ b/Plugin/AbstractPlugin.php
@@ -47,9 +47,18 @@ abstract class AbstractPlugin
 
     protected function canExecute()
     {
-        return !$this->helperFactory->getObject('Module\Maintenance')->isEnabled() &&
-               !$this->helperFactory->getObject('Module')->isDisabled() &&
-               $this->helperFactory->getObject('Module')->isReadyToWork();
+        return !$this->isInstalling() &&
+                !$this->helperFactory->getObject('Module\Maintenance')->isEnabled() &&
+                !$this->helperFactory->getObject('Module')->isDisabled() &&
+                $this->helperFactory->getObject('Module')->isReadyToWork();
+    }
+
+    private function isInstalling()
+    {
+        return isset($_SERVER['SCRIPT_NAME']) &&
+            $_SERVER['SCRIPT_NAME'] == 'bin/magento' &&
+            isset($_SERVER['argv']) &&
+            in_array('setup:install', $_SERVER['argv']);
     }
 
     //########################################


### PR DESCRIPTION
There seem to be a problem here. The plugin is disabled during maintenance but not during installation and it's apparently causing the installation to crash.

I've patched it with a very quick and dirt low level check, but I reckon the flaw is likely to be in the plugin design.

Please do not merge this request, but instead, investigate the installation issue.