### PR TITLE
Fix for compact deploy mode

### DIFF
--- a/Helper/Magento.php
+++ b/Helper/Magento.php
@@ -310,7 +310,19 @@ class Magento extends \Ess\M2ePro\Helper\AbstractHelper
             $basePath .= $path;
         }
 
-        return $directoryReader->isExist($basePath);
+        $exist = $directoryReader->isExist($basePath);
+        if (!$exist) {
+            $themePath = str_replace('backend','base', $this->getThemePath());
+            $basePath = $themePath . DIRECTORY_SEPARATOR
+                . 'default' . DIRECTORY_SEPARATOR;
+
+            if (!is_null($path)) {
+                $basePath .= $path;
+            }
+            $exist = $directoryReader->isExist($basePath);
+        }
+
+        return $exist;
     }
 
     public function getLastStaticContentDeployDate()


### PR DESCRIPTION
We had an error "M2E Pro interface cannot work properly and there is no way to work with it correctly, as your Magento is set to the Production Mode and the static content data was not deployed..." if we used compact deploy strategy in production mode, like so:

`php bin/magento setup:static-content:deploy --strategy compact`

This pull request solved that problem.