### PR TITLE
Exception when saving Shipment with tracking number

### DIFF
--- a/Model/Order/Shipment/Handler.php
+++ b/Model/Order/Shipment/Handler.php
@@ -89,7 +89,7 @@ class Handler extends \Ess\M2ePro\Model\AbstractModel
         }
 
         /** @var \Magento\Sales\Model\Order\Shipment\Track $track */
-        $track  = reset($tracks);
+        $track  = is_array($tracks) ? reset($tracks) : $tracks->getItems(){0};
         $number = trim($track->getData('track_number'));
 
         if (empty($number)) {


### PR DESCRIPTION
When $shipment->getTracks() returns a Collection reset() function cannot be used