### PR TITLE
Set variant names for bundle product

### DIFF
--- a/Block/Adminhtml/Ebay/Listing/Preview.php
+++ b/Block/Adminhtml/Ebay/Listing/Preview.php
@@ -458,6 +458,18 @@ JS
             if ($this->ebayListingProduct->getMagentoProduct()->isGroupedType()) {
                 $attributeLabels = [\Ess\M2ePro\Model\Magento\Product\Variation::GROUPED_PRODUCT_ATTRIBUTE_LABEL];
             }
+            
+            if ($this->ebayListingProduct->getMagentoProduct()->isBundleType()) {				
+			   foreach ($this->ebayListingProduct->getVariations(true) as $variation) {
+					if ($variation->getChildObject()->isDelete() || !$variation->getChildObject()->getQty()) {
+						continue;
+					}
+					foreach ($variation->getOptions(true) as $option) {
+						$attributeLabels [] = trim($option->getAttribute());
+					}
+				}				
+            }
+            
 
             if (!empty($attributeLabels)) {
                 $images['variations'] = $this->getImagesDataByAttributeLabels($attributeLabels);

--- a/Model/Ebay/Listing/Product/Action/Request/Variations.php
+++ b/Model/Ebay/Listing/Product/Action/Request/Variations.php
@@ -227,6 +227,20 @@ class Variations extends \Ess\M2ePro\Model\Ebay\Listing\Product\Action\Request\A
         if ($this->getMagentoProduct()->isGroupedType()) {
             $attributeLabels = [\Ess\M2ePro\Model\Magento\Product\Variation::GROUPED_PRODUCT_ATTRIBUTE_LABEL];
         }
+        
+        if ($this->getMagentoProduct()->isBundleType()) {   
+		   foreach ($this->getListingProduct()->getVariations(true) as $variation) {
+				if ($variation->getChildObject()->isDelete() || !$variation->getChildObject()->getQty()) {
+					continue;
+				}
+				foreach ($variation->getOptions(true) as $option) {
+					/** @var $option \Ess\M2ePro\Model\Listing\Product\Variation\Option */
+					$attributeLabels [] = trim($option->getAttribute());
+				}
+			}
+		   
+        }
+
 
         if (count($attributeLabels) <= 0) {
             return [];


### PR DESCRIPTION
This extension sets the names of the variants of a bundle product to the array. Hereby the images of the variant products are transferred to ebay. The images change with the selection of the variant.
The algorithm is not optimal, because the names occur several times in the array. But the images are only transmitted once.