### PR TITLE
Fix variable name in public services structural model

### DIFF
--- a/PublicServices/Product/SqlChange.php
+++ b/PublicServices/Product/SqlChange.php
@@ -185,13 +185,13 @@ class SqlChange extends \Ess\M2ePro\Model\AbstractModel
 
     protected function getInstructionsData()
     {
-        if (empty($this->_changesData)) {
+        if (empty($this->changesData)) {
             return [];
         }
 
         $productInstructionTypes = [];
 
-        foreach ($this->_changesData as $changeData) {
+        foreach ($this->changesData as $changeData) {
             $productId = (int)$changeData['product_id'];
 
             $productInstructionTypes[$productId][] = $changeData['instruction_type'];


### PR DESCRIPTION
Incorrect variable name is causing updates not to be processed or added to the m2epro_listing_product_instruction DB table