### PR TITLE
OptionsFinder::getGroupedAssociatedProduct made public

### DIFF
--- a/Model/Order/Item/OptionsFinder.php
+++ b/Model/Order/Item/OptionsFinder.php
@@ -300,7 +300,7 @@ class OptionsFinder extends \Ess\M2ePro\Model\AbstractModel
         $products["{$optionId}::{$valueId}"] = $this->magentoValue['product_ids'];
     }
 
-    private function getGroupedAssociatedProduct()
+    public function getGroupedAssociatedProduct()
     {
         $variationName = array_shift($this->channelOptions);
 


### PR DESCRIPTION
This is a small, single file change that changes the \Ess\M2ePro\Model\Order\Item\OptionsFinder::getGroupedAssociatedProduct method from private to public. This allows for plugins to apply custom logic to determine what product the order item is linked to.

This change won't cause any run time effects because changing a method from private to public doesn't take anything away (unlike if it was reversed).

If for some reason this change isn't possible, converting the method from private to protected would at least allow modification to the method using a preference.