### PR TITLE
Fix for Warning: Failed to set memory limit to 33554432 bytes 

### DIFF
--- a/Helper/Client.php
+++ b/Helper/Client.php
@@ -367,6 +367,10 @@ class Client extends AbstractHelper
 
         // @codingStandardsIgnoreStart
         for ($i=$minSize; $i<=$maxSize; $i*=2) {
+            if ($currentMemoryLimit >= $i) {
+                continue;
+            }
+
             if (ini_set('memory_limit', "{$i}M") === false) {
                 if ($i == $minSize) {
                     return false;


### PR DESCRIPTION
**Failed to set memory limit to 33554432 bytes  (Current memory usage is 337641472 bytes)**

We use php 7.4.22 but starting from php version 7.4.20, when changing the memory limit, additional checks for a new value began to take effect, so we cannot specify a value less than 2mb. https://php.watch/versions/7.4/memory_limit-lt-2m

![image](https://user-images.githubusercontent.com/1055999/146773367-ca4aad98-261d-441e-a1b3-48a0b422e24e.png)

But the m2epro code starts apply through values starting from 32mb and increases twice until it hits the maximum https://github.com/m2epro/magento2-extension/blob/master/Helper/Client.php#L369 

But we most likely have another problem, when m2epro sets the value to 32mb, then at this moment we already have more memory allocated, judging by the error text, this is already more than 300mb:
```
[2021-12-16 19:17:03] report.CRITICAL: Warning: Failed to set memory limit to 33554432 bytes (Current memory usage is 337641472 bytes) in /vendor/m2epro/magento2-extension/Helper/Client.php on line 362 {"exception":"[object] (Exception(code: 0): Warning: Failed to set memory limit to 33554432 bytes (Current memory usage is 337641472 bytes) in /vendor/m2epro/magento2-extension/Helper/Client.php on line 362 at /vendor/magento/framework/App/ErrorHandler.php:61)"} []
```

I also found the following bug https://bugs.php.net/bug.php?id=81104

And I was able to reproduce it locally, immediately I analysed how much memory is allocated, and then I tried to set the memory limit a little more than it is allocated - everything works correctly, and then a little less memory - and the error reproduced

![image](https://user-images.githubusercontent.com/1055999/146773944-bac11bc0-be14-4005-8457-a96b46779e14.png)

**Solution**: there is no need to set the memory limit values less than current limit value, so these values can be skipped.