### PR TITLE
Error when name has double spaces

### DIFF
--- a/Model/Order/ProxyObject.php
+++ b/Model/Order/ProxyObject.php
@@ -362,7 +362,7 @@ abstract class ProxyObject extends \Ess\M2ePro\Model\AbstractModel
      */
     protected function getNameParts($fullName)
     {
-        $fullName = trim($fullName);
+        $fullName = trim(preg_replace('/\s+/', ' ', $fullName));
         $parts = explode(' ', $fullName);
 
         $currentInfo = [


### PR DESCRIPTION
e.g. Mr  J Smith - results in error 

Magento Order was not created. Reason: Please check the shipping address information. "firstname" is required. Enter and try again.