### PR TITLE
Move config plugin from general di.xml to adminhtml di.xml

### DIFF
--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -117,4 +117,11 @@
                 type="Ess\M2ePro\Plugin\Order\Magento\View" />
     </type>
 
+    <!-- order -->
+
+    <type name="Magento\Framework\App\Config">
+        <plugin name="m2epro_plugin_order_magento_framework_app_config"
+                type="Ess\M2ePro\Plugin\Order\Magento\Framework\App\Config" />
+    </type>
+
 </config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -19,11 +19,6 @@
 
     <!-- order -->
 
-    <type name="Magento\Framework\App\Config">
-        <plugin name="m2epro_plugin_order_magento_framework_app_config"
-                type="Ess\M2ePro\Plugin\Order\Magento\Framework\App\Config" />
-    </type>
-
     <type name="Magento\Quote\Model\Quote\Item\ToOrderItem">
         <plugin name="m2epro_plugin_order_magento_quote_model_quote_item_toorderitem"
                 type="Ess\M2ePro\Plugin\Order\Magento\Quote\Model\Quote\Item\ToOrderItem" />


### PR DESCRIPTION
This is a proposal for a slight performance improvement.
The around plugin for getValue is always executed on frontend, whereas m2e has nothing to do on frontend, imho.
This around plugin adds a performance delay, e.g. on checkout page, where the page is not fetched from cache.
See the picture below, which shows the miliseconds this plugin adds. Note that this is from a development environment, so the delay will be shorter on a production environment, but will still be there unnecessarily. 
![aroundPlugin](https://user-images.githubusercontent.com/18382633/195056957-9f62683c-780c-4dd3-9f23-3a42adcbef71.png)

