### PR TITLE
Update AbstractForm.php to resolve error in magento 2.4.5

### DIFF
--- a/Block/Adminhtml/Magento/Form/AbstractForm.php
+++ b/Block/Adminhtml/Magento/Form/AbstractForm.php
@@ -71,7 +71,16 @@ abstract class AbstractForm extends Generic
 
         parent::__construct($context, $registry, $formFactory, $data);
     }
-
+    
+    public function getForm()
+    {
+        if ($this->_form == null) {
+            return $this->_formFactory->create();
+        } else {
+            return $this->_form;
+        }
+    }
+    
     protected function _prepareLayout()
     {
         parent::_prepareLayout();


### PR DESCRIPTION
Added override of \Magento\Backend\Block\Widget\Form method getForm to resolve Error: "RemovePasswordAndUserConfirmationFormFieldsPlugin::afterGetForm(): Argument #2 ($result) must be of type Magento\Framework\Data\Form, null" in magento 2.4.5, as addressed in https://github.com/magento/magento2/issues/36145